### PR TITLE
Dev fix tot outputs

### DIFF
--- a/Analysis/R/prepare_stan_input.R
+++ b/Analysis/R/prepare_stan_input.R
@@ -609,7 +609,8 @@ prepare_stan_input <- function(
   
   # Space-only location periods
   output_lps_space <- fake_output_obs %>% 
-    dplyr::distinct(locationPeriod_id)
+    dplyr::distinct(locationPeriod_id) %>% 
+    dplyr::arrange(locationPeriod_id)
   
   # Set data for output in stan object
   stan_data$M_output <- nrow(fake_output_obs)

--- a/packages/taxdat/R/covariate_helpers.R
+++ b/packages/taxdat/R/covariate_helpers.R
@@ -1378,7 +1378,8 @@ get_multi_country_admin_units <- function(iso_code,
     purrr::map_df(admin_levels, 
                   ~ get_country_admin_units(iso_code = iso_code, 
                                             admin_level = .) %>% 
-                    dplyr::rename(admin_level = shapeType)
+                    dplyr::rename(admin_level = shapeType) %>% 
+                    dplyr::arrange(location_period_id)
     )
   }
 }


### PR DESCRIPTION
Fix missmatch in ordering of location periods in output dataframe. This was done by ordering by location_period_id.