### PR TITLE
ensure to remove all spacetime cells corresponding to low popfrac

### DIFF
--- a/Analysis/R/prepare_covar_cube.R
+++ b/Analysis/R/prepare_covar_cube.R
@@ -153,6 +153,7 @@ prepare_covar_cube <- function(
     dplyr::group_by(rid, x, y) %>% 
     dplyr::slice_max(pop_weight) %>% 
     dplyr::filter(pop_weight < 1e-4) %>% 
+    dplyr::select(rid, x, y) %>% 
     dplyr::inner_join(sf_grid %>% sf::st_drop_geometry())
   
   # Re-define grid cells to remove cells with low sf_frac
@@ -170,7 +171,7 @@ prepare_covar_cube <- function(
   
   # close database
   DBI::dbDisconnect(conn_pg)
-
+  
   covar_cube <- taxdat::transform_covariates(covar_cube, covariate_transformations)
   
   # Assemble output


### PR DESCRIPTION
The bug was in joining the dataframe with low spatial fractions on sf_grid using long_id. The fix is to keep only rid,x,y.