### PR TITLE
Update shapefile_utils.R

### DIFF
--- a/packages/taxdat/R/shapefile_utils.R
+++ b/packages/taxdat/R/shapefile_utils.R
@@ -98,7 +98,7 @@ drop_missing_shapefiles <- function(cases,
 get_valid_shapefiles <- function(cases) {
   
   shapefiles <- cases %>%
-    dplyr::group_by(attributes.location_period_id) %>%
+    dplyr::group_by(attributes.location_period_id, location_name) %>%
     dplyr::slice(1) %>% 
     dplyr::rename(location_period_id = attributes.location_period_id) %>% 
     dplyr::ungroup()


### PR DESCRIPTION
To fix the issue that sf_cases object is different in different runs; when generating valid shapefiles from cases object pulled from taxonomy database, group by both location period id and location name since there are some location period id linked to more than one location name. In this case, all the observations with different location names linked to the same location period id will be able to be kept.