### PR TITLE
New shell script to install R packages for R 4.2 on Rockfish

### DIFF
--- a/Rockfish.Rprofile
+++ b/Rockfish.Rprofile
@@ -1,0 +1,9 @@
+home <- Sys.getenv("HOME")
+
+user_lib <- paste0(home, "/R/x86_64-pc-linux-gnu-library/4.2")
+# We set personal library path as the default one
+.libPaths(c(user_lib, "/data/apps/extern/easybuild/R/4.2.1-foss-2022a/lib64/R/library"))
+options(repos = c(
+  CRAN = "https://cran.r-project.org",
+  CMDSTANR = "https://mc-stan.org/r-packages/"
+))

--- a/shell_scripts/marcc_install_cmdstan_r42.sh
+++ b/shell_scripts/marcc_install_cmdstan_r42.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+#SBATCH --job-name=install_cmdstan
+#SBATCH --time=00:30:00
+#SBATCH --mem=16G
+#SBATCH --ntasks=1
+#SBATCH --partition=defq
+#SBATCH --account=aazman1
+# set SBATCH --output based on your directory structure
+
+CMDSTAN_LOCATION=/data/aazman1/pfang3/cmdstan_42
+R_LIBRARY_DIRECTORY=$HOME/R/x86_64-pc-linux-gnu-library/4.2
+CHOLERA_PIPELINE_DIRECTORY=/data/aazman1/$USER/cholera-mapping-pipeline/
+
+## clone cmdstan (will not fail if already cloned)
+git clone https://github.com/stan-dev/cmdstan.git $CMDSTAN_LOCATION --recurse-submodules
+cd $CMDSTAN_LOCATION
+
+## Update cmdstan
+# git reset --hard $CMDSTAN_LOCATION
+# git clean -fxd $CMDSTAN_LOCATION
+# git pull
+
+
+## Set up modules
+## (we need to do git things since reset removes git)
+module purge
+module load GCC/11.3.0
+module load R/4.2.1-foss-2022a
+module load openmpi
+module load gdal
+
+
+## Actually install cmdstanr including dependent r packages and cmdstan
+mkdir -p $R_LIBRARY_DIRECTORY \
+ && cd $CMDSTAN_LOCATION \
+ && make build \
+ && Rscript -e "options(error=quit, status = 1); source('${CHOLERA_PIPELINE_DIRECTORY}Rockfish.Rprofile'); install.packages('cmdstanr', lib='$R_LIBRARY_DIRECTORY')"
+ #
+
+echo "DONE"

--- a/shell_scripts/marcc_install_taxdat-related_packages_r42.sh
+++ b/shell_scripts/marcc_install_taxdat-related_packages_r42.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+#SBATCH --job-name get_pkg
+#SBATCH --time=3-00:00:00
+#SBATCH --mem=16G
+#SBATCH --ntasks=4
+#SBATCH --partition=defq
+#SBATCH --account=aazman1
+# set SBATCH --output based on your directory structure
+
+module purge
+
+ml GCC/11.3.0
+ml openmpi
+ml gdal
+ml R/4.2.1-foss-2022a
+
+export CHOLERA_ON_MARCC=TRUE
+export CHOLERA_PIPELINE_DIRECTORY=/data/aazman1/$USER/cholera-mapping-pipeline/
+export R_LIBS_USER=$HOME/R/x86_64-pc-linux-gnu-library/4.2/
+
+# sf, terra, ISOcodes,igraph, roxygen2, withr, processx included in module R/4.2.1 can be removed from install
+mkdir -p $R_LIBS_USER \
+ && Rscript -e "source('${CHOLERA_PIPELINE_DIRECTORY}Rockfish.Rprofile');
+                options(error=quit, status = 1); 
+                package_list <- c('geodata'); 
+                for (pkg in package_list){
+                    if (!require(package = pkg, lib='$R_LIBS_USER')) {
+                        install.packages(pkg, lib='$R_LIBS_USER') 
+                    }; 
+                };
+                install.packages('${CHOLERA_PIPELINE_DIRECTORY}packages/taxdat', type='source', repos = NULL, lib='$R_LIBS_USER')"                
+echo "DONE"
+

--- a/shell_scripts/marcc_install_taxdat_r42.sh
+++ b/shell_scripts/marcc_install_taxdat_r42.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+#SBATCH --job-name get_pkg
+#SBATCH --time=3-00:00:00
+#SBATCH --mem=16G
+#SBATCH --ntasks=4
+#SBATCH --partition=defq
+#SBATCH --account=aazman1
+# set SBATCH --output based on your directory structure
+
+module purge
+
+ml GCC/11.3.0
+ml openmpi
+ml gdal
+ml R/4.2.1-foss-2022a
+
+export CHOLERA_ON_MARCC=TRUE
+export CHOLERA_PIPELINE_DIRECTORY=/data/aazman1/$USER/cholera-mapping-pipeline/
+export R_LIBS_USER=$HOME/R/x86_64-pc-linux-gnu-library/4.2/
+
+# sf, terra, ISOcodes,igraph, roxygen2, withr, processx included in module R/4.2.1 can be removed from install
+mkdir -p $R_LIBS_USER \
+ && Rscript -e "source('${CHOLERA_PIPELINE_DIRECTORY}Rockfish.Rprofile');
+                options(error=quit, status = 1); 
+                package_list <- c('geodata'); 
+                for (pkg in package_list){
+                    if (!require(package = pkg, lib='$R_LIBS_USER')) {
+                        install.packages(pkg, lib='$R_LIBS_USER') 
+                    }; 
+                };
+                install.packages('${CHOLERA_PIPELINE_DIRECTORY}packages/taxdat', type='source', repos = NULL, lib='$R_LIBS_USER')"                
+echo "DONE"
+


### PR DESCRIPTION
Add new shell scripts and a specific Rprofile for Rockfish, which are used to install cmdstanr and taxdat.